### PR TITLE
fixed an issue where "tmp-ck-timer.json" could not be generated while…

### DIFF
--- a/program/cbench-security-pgp/pgp.c
+++ b/program/cbench-security-pgp/pgp.c
@@ -1148,8 +1148,12 @@ phone +1 303 541-0140\n"));
 #endif
 	if (batchmode && !signature_checked)
 	    exitPGP(1);		/* alternate success, file did not have sig. */
-	else
-	    exitPGP(EXIT_OK);
+	else {
+		xopenme_clock_end(0);
+		xopenme_dump_state();
+		xopenme_finish();
+		exitPGP(EXIT_OK);
+	}
     }
     /*
      * See if plaintext input file was actually created by PGP earlier--


### PR DESCRIPTION
… executing cbench-security-pgp

When we perform "ck crowdsource program. Optimization: cbench ws-security-pgp --local" command,
the following error has been encountered encountered:

  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   CK detected a PROBLEM in the third-party CK program workflow:

   Failed(?) CK program: cbench-security-pgp
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   Please, submit the log to the community of this external CK program workflow at "https://groups.google.com/forum/#!forum/collective-knowledge" to collaboratively fix this problem!

***************************************************************************************
Pipeline failed (execution failed - problem opening json file=tmp-ck-timer.json ([Errno 2] No such file or directory: u'tmp-ck-timer.json'))!
***************************************************************************************
Done!

   WARNING: pipeline execution failed (execution failed - problem opening json file=tmp-ck-timer.json ([Errno 2] No such file or directory: u'tmp-ck-timer.json')) ...